### PR TITLE
remove newlines from summary

### DIFF
--- a/web/pd2jira.php
+++ b/web/pd2jira.php
@@ -35,6 +35,7 @@ if ($messages) foreach ($messages->messages as $webhook) {
       }
 
       $summary = "PagerDuty Service: $service_name, Incident #$incident_number, Summary: $trigger_summary_data";
+      $summary = trim(preg_replace('/\s+/', ' ', $summary));
       $summary = (strlen($summary) > 255) ? substr($summary,0,252) . '...' : $summary;
 
       $verb = "triggered";


### PR DESCRIPTION
fixes this issue:
A JIRA ticket failed to be created.
{"errorMessages":[],"errors":{"summary":"The summary is invalid because
it contains newline characters."}}